### PR TITLE
ffmpeg: fix .i64 -> .str for asm option

### DIFF
--- a/ffmpeg/vf_raisr.c
+++ b/ffmpeg/vf_raisr.c
@@ -84,7 +84,7 @@ static const AVOption raisr_options[] = {
     {"blending", "CT blending mode (1: Randomness, 2: CountOfBitsChanged)", OFFSET(blending), AV_OPT_TYPE_INT, {.i64 = BLENDING_COUNT_OF_BITS_CHANGED}, BLENDING_RANDOMNESS, BLENDING_COUNT_OF_BITS_CHANGED, FLAGS},
     {"passes", "passes to run (1: one pass, 2: two pass)", OFFSET(passes), AV_OPT_TYPE_INT, {.i64 = 1}, 1, 2, FLAGS},
     {"mode", "mode for two pass (1: upscale in 1st pass, 2: upscale in 2nd pass)", OFFSET(mode), AV_OPT_TYPE_INT, {.i64 = 1}, 1, 2, FLAGS},
-    {"asm", "x86 asm type: (avx512 or avx2)", OFFSET(asmStr), AV_OPT_TYPE_STRING, {.i64 = "avx512"}, 0, 0, FLAGS},
+    {"asm", "x86 asm type: (avx512 or avx2)", OFFSET(asmStr), AV_OPT_TYPE_STRING, {.str = "avx512"}, 0, 0, FLAGS},
     {NULL}};
 
 AVFILTER_DEFINE_CLASS(raisr);


### PR DESCRIPTION
causes a compilation error with clang >= 16