### PR TITLE
Make output resolution to even 

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ ffmpeg -init_hw_device vaapi=va -init_hw_device qsv=qs@va -init_hw_device opencl
 ffmpeg -init_hw_device vaapi=va -init_hw_device opencl=ocl@va -hwaccel vaapi -hwaccel_output_format vaapi -i input.264 -vf "hwmap=derive_device=opencl,format=opencl,raisr_opencl,hwmap=derive_device=vaapi:reverse=1:extra_hw_frames=16" -c:v hevc_vaapi output.mp4
 ```
 
+**Even output**
+
+There are certain codecs that support only even resolution, the `evenoutput` parameter will support users to choose whether to make the output an even number
+
+Set `evenoutput=1` to make output size as even number, the following command will get 632x632 output.
+```
+ffmpeg -i input.mp4 -an -vf scale=422x422,raisr=ratio=1.5:filterfolder=filters_1.5x/filters_highres:threadcount=1:evenoutput=1 output.mp4
+```
+It will keep the output resolution as the input resolution multiply by the upscaling ratio if set `evenoutput=0` or not set the parameter, will get 633x633 output with 422x422 input.
 
 ## To see help on the RAISR filter
 `./ffmpeg -h filter=raisr`
@@ -89,6 +98,7 @@ ffmpeg -init_hw_device vaapi=va -init_hw_device opencl=ocl@va -hwaccel vaapi -hw
       asm               <string>     ..FV....... x86 asm type: (avx512fp16, avx512, avx2 or opencl) (default "avx512fp16")
       platform          <int>        ..FV....... select the platform (from 0 to INT_MAX) (default 0)
       device            <int>        ..FV....... select the device (from 0 to INT_MAX) (default 0)
+      evenoutput        <int>        ..FV....... make output size as even number (0: ignore, 1: subtract 1px if needed) (from 0 to 1) (default 0)
 
 
 # How to Contribute

--- a/ffmpeg/vf_raisr.c
+++ b/ffmpeg/vf_raisr.c
@@ -211,6 +211,9 @@ static int config_props_output(AVFilterLink *outlink)
 
     outlink->w = inlink0->w * raisr->ratio;
     outlink->h = inlink0->h * raisr->ratio;
+    // resolution of output needs to be even due to encoder support only even resolution
+    outlink->w = outlink->w % 2 == 0 ? outlink->w : outlink->w - 1 ;
+    outlink->h = outlink->h % 2 == 0 ? outlink->h : outlink->h - 1;
 
     return 0;
 }
@@ -224,6 +227,7 @@ static int filter_frame(AVFilterLink *inlink, AVFrame *in)
     RNLERRORTYPE ret;
     VideoDataType vdt_in[3] = { 0 };
     VideoDataType vdt_out[3] = { 0 };
+    const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(outlink->format);
 
     av_log(ctx, AV_LOG_VERBOSE, "Frame\n");
 
@@ -263,10 +267,15 @@ static int filter_frame(AVFilterLink *inlink, AVFrame *in)
         vdt_in[p].height = plane->height;
         vdt_in[p].step = in->linesize[p];
 
+        // Get horziontal and vertical power of 2 factors
+        int vsub = p ? desc->log2_chroma_h : 0;
+        int hsub = p ? desc->log2_chroma_w : 0;
+
         // fill in the output video data type structure
         vdt_out[p].pData = out->data[p];
-        vdt_out[p].width = plane->width * raisr->ratio;
-        vdt_out[p].height = plane->height * raisr->ratio;
+        // Determine the width and height of this plane/channel
+        vdt_out[p].width = AV_CEIL_RSHIFT(out->width, hsub);
+        vdt_out[p].height = AV_CEIL_RSHIFT(out->height, vsub);
         vdt_out[p].step = out->linesize[p];
     }
     if (raisr->framecount == 0)

--- a/ffmpeg/vf_raisr_opencl.c
+++ b/ffmpeg/vf_raisr_opencl.c
@@ -43,6 +43,7 @@ typedef struct RaisrOpenCLContext {
     int mode;
     RangeType range;
     enum AVPixelFormat sw_format;
+    int evenoutput;
 } RaisrOpenCLContext;
 
 
@@ -196,9 +197,10 @@ static int raisr_opencl_config_output(AVFilterLink *outlink)
 
     ctx->ocf.output_width = inlink->w * ctx->ratio;
     ctx->ocf.output_height = inlink->h * ctx->ratio;
-    // resolution of output needs to be even due to encoder support only even resolution
-    ctx->ocf.output_width = ctx->ocf.output_width % 2 == 0 ? ctx->ocf.output_width : ctx->ocf.output_width - 1;
-    ctx->ocf.output_height = ctx->ocf.output_height % 2 == 0 ? ctx->ocf.output_height : ctx->ocf.output_height - 1;
+    if (ctx->evenoutput == 1) {
+        ctx->ocf.output_width -= ctx->ocf.output_width % 2;
+        ctx->ocf.output_height -= ctx->ocf.output_height % 2;
+    }
 
     err = ff_opencl_filter_config_output(outlink);
     if (err < 0)
@@ -229,6 +231,7 @@ static const AVOption raisr_opencl_options[] = {
         { "CountOfBitsChanged", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = CountOfBitsChanged   },   INT_MIN, INT_MAX, FLAGS, "blending" },
     {"passes", "passes to run (1: one pass, 2: two pass)", OFFSET(passes), AV_OPT_TYPE_INT, {.i64 = 1}, 1, 2, FLAGS},
     {"mode", "mode for two pass (1: upscale in 1st pass, 2: upscale in 2nd pass)", OFFSET(mode), AV_OPT_TYPE_INT, {.i64 = 1}, 1, 2, FLAGS},
+    {"evenoutput", "make output size as even number (0: ignore, 1: subtract 1px if needed)", OFFSET(evenoutput), AV_OPT_TYPE_INT, {.i64 = 0}, 0, 1, FLAGS},
     {NULL}
 };
 


### PR DESCRIPTION
Make output resolution to even due to encoder only support even resolution.
And fixed core dump issue when running on some input odd resolutions.