### PR TITLE
fix in building script

### DIFF
--- a/scripts/03_build_raisr_ffmpeg.sh
+++ b/scripts/03_build_raisr_ffmpeg.sh
@@ -49,9 +49,10 @@ cp "${raisr_path}/ffmpeg/vf_raisr.c" libavfilter/
 make clean
 make -j"$(nproc)"
 sudo -E make install
-popd
 
+# copy filters to ffmpeg directory
 cp -r "${raisr_path}/filters"* .
+popd
 
 log_info "\tTo run the library you can do the following:"
 log_info


### PR DESCRIPTION
Following the script to build: https://github.com/OpenVisualCloud/Video-Super-Resolution-Library/blob/main/How%20to%20build.md#build-via-scripts,
User will meet the issue that the filter configuration file is not found: https://github.com/OpenVisualCloud/Video-Super-Resolution-Library/blob/main/scripts/03_build_raisr_ffmpeg.sh#L59.

This PR is the fix to avoid the issue.