### PR TITLE
Workaround to make FFmpeg buildable with binutil>=2.41

### DIFF
--- a/scripts/03_build_raisr_ffmpeg.sh
+++ b/scripts/03_build_raisr_ffmpeg.sh
@@ -31,6 +31,9 @@ pushd "${raisr_path}"
 sudo -E ./build.sh
 popd
 
+# cherry pick the fix to build with binutil >= 2.41. Remove it with later FFmpeg version
+git cherry-pick effadce6c756247ea8bae32dc13bb3e6f464f0eb
+
 # build ffmpeg
 pushd "${raisr_path}/../ffmpeg"
 cp "${raisr_path}/ffmpeg/vf_raisr.c" libavfilter/


### PR DESCRIPTION
Chrry-pick the commit to provide this workaround to make FFmpeg n6.1 buildable with binutil >= 2.41.