### PR TITLE
FIX: Allow a force build for AVX512fp16 and AVX512

### DIFF
--- a/.github/workflows/build-baremetal-coverity.yml
+++ b/.github/workflows/build-baremetal-coverity.yml
@@ -85,7 +85,7 @@ jobs:
         token: ${{ secrets.COVERITY_SCAN_TOKEN }}
         build_language: 'cxx'
         build_platform: 'linux64'
-        command: ${{ github.workspace }}/./build.sh -DENABLE_RAISR_OPENCL=ON -DCMAKE_LIBRARY_PATH="/opt/intel/oneapi/ipp/latest/lib;${PREFIX}/lib;" -DCMAKE_C_FLAGS="-I/opt/intel/oneapi/ipp/latest/include -I/opt/intel/oneapi/ipp/latest/include/ipp" -DCMAKE_CXX_FLAGS="-I/opt/intel/oneapi/ipp/latest/include -I/opt/intel/oneapi/ipp/latest/include/ipp"
+        command: ${{ github.workspace }}/./build.sh -DENABLE_RAISR_OPENCL=ON -DENABLE_AVX512FP16=ON -DENABLE_AVX512=ON
 
     - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,15 @@ if (ENABLE_RAISR_OPENCL)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DENABLE_RAISR_OPENCL")
 endif()
 
+option( ENABLE_AVX512FP16 "Build AVX512fp16 despite test results" OFF )
+if (ENABLE_AVX512FP16)
+    set(HAVE_AVX512FP16 ON)
+endif()
 
+option( ENABLE_AVX512 "Build AVX512 despite test results" OFF )
+if (ENABLE_AVX512)
+    set(HAVE_AVX512 ON)
+endif()
 # Intel Library for Video Super Resolution
 add_subdirectory(Library)
 


### PR DESCRIPTION
FIX: Allow a force build for `AVX512fp16` and `AVX512` by using `-DENABLE_AVX512FP16=ON` and `-DENABLE_AVX512=ON` flags.
Add: Mandatory changes for flags `ENABLE_AVX512` and `ENABLE_AVX512FP16` to work as intended.